### PR TITLE
Remove copied packaging metadata

### DIFF
--- a/islandora_embed_theme.info
+++ b/islandora_embed_theme.info
@@ -4,12 +4,3 @@ package = Entity iframe
 core = 7.x
 stylesheets[all][] = layout.css
 scripts[] = js/embed_internet_archive_bookreader.js
-
-; Information added by Drupal.org packaging script on 2014-06-09
-version = "7.x-1.0"
-core = "7.x"
-project = "entity_iframe_theme"
-datestamp = "1402321138"
-
-
-


### PR DESCRIPTION
Removes `.info` metadata mistakenly copied from module at d.o. 

This is mostly innocuous, but leads to some errors when Drupal tries to check for updates. 